### PR TITLE
add error context for unhandled errors

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -70,11 +70,15 @@ export class ActionHelperImpl<TPayload, TResult>
     const promise = new NyaxPromise<TResult>((resolve, reject) => {
       this._nyaxContext.dispatchDeferredByAction.set(action, {
         resolve,
-        reject: (reason) => {
+        reject: (reason, context) => {
           reject(reason);
           Promise.resolve().then(() => {
             if (!promise.hasRejectionHandler) {
-              this._nyaxContext.onUnhandledEffectError(reason, promise);
+              this._nyaxContext.onUnhandledEffectError(
+                reason,
+                promise,
+                context
+              );
             }
           });
         },

--- a/src/epic.ts
+++ b/src/epic.ts
@@ -22,7 +22,9 @@ export function createEpic(
       outputObservables.push(
         epic().pipe(
           catchError((error, caught) => {
-            return nyaxContext.onUnhandledEpicError(error, caught);
+            return nyaxContext.onUnhandledEpicError(error, caught, {
+              container,
+            });
           })
         )
       );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -130,9 +130,15 @@ export function createMiddleware(nyaxContext: NyaxContext): Middleware {
             },
             (reason) => {
               if (dispatchDeferred) {
-                dispatchDeferred.reject(reason);
+                dispatchDeferred.reject(reason, {
+                  container,
+                  action,
+                });
               } else {
-                nyaxContext.onUnhandledEffectError(reason, undefined);
+                nyaxContext.onUnhandledEffectError(reason, undefined, {
+                  container,
+                  action,
+                });
               }
             }
           );

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,7 +14,7 @@ import {
   reloadActionHelper,
 } from "./action";
 import { Container, GetContainer } from "./container";
-import { createNyaxContext } from "./context";
+import { createNyaxContext, ErrorContext } from "./context";
 import { createMiddleware } from "./middleware";
 import { Models, registerModels } from "./model";
 import { GetState } from "./state";
@@ -30,11 +30,13 @@ export interface NyaxOptions {
 
   onUnhandledEffectError?: (
     error: unknown,
-    promise: Promise<unknown> | undefined
+    promise: Promise<unknown> | undefined,
+    context?: ErrorContext
   ) => void;
   onUnhandledEpicError?: (
     error: unknown,
-    caught: Observable<AnyAction>
+    caught: Observable<AnyAction>,
+    context?: ErrorContext
   ) => Observable<AnyAction>;
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -774,15 +774,18 @@ describe("nyax", () => {
 
     const { getContainer, registerModels } = createNyax({
       dependencies,
-      onUnhandledEffectError: (error, promise) => {
+      onUnhandledEffectError: (error, promise, context) => {
         promise?.catch(() => {
           // noop
         });
         expect((error as Error).message).eq("effect error");
+        expect(context?.container?.modelNamespace).eq("err");
+        expect(!!context?.action?.type).eq(true);
         effectErrorCounter += 1;
       },
-      onUnhandledEpicError: (error, caught) => {
+      onUnhandledEpicError: (error, caught, context) => {
         expect((error as Error).message).eq("epic error");
+        expect(context?.container?.modelNamespace).eq("err");
         epicErrorCounter += 1;
         return caught;
       },


### PR DESCRIPTION
Add more information when unhandled errors were thrown out, including context of `Container`, `Action`

This is to get more information for better troubleshooting and event logging when unhandled errors occur.