### PR TITLE
[0.5.x] support customized namespace separator

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -104,7 +104,11 @@ export function createActionHelpers<TModel extends Model>(
   mergeObjects(actionHelpers, obj, (item, key, parent, paths) => {
     parent[key] = new ActionHelperImpl(
       nyaxContext,
-      joinLastString(container.namespace, paths.join("."))
+      joinLastString(
+        container.namespace,
+        paths.join(nyaxContext.options.subModelSeparator ?? "."),
+        nyaxContext.options.namespaceSeparator
+      )
     );
   });
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -100,7 +100,11 @@ export class ContainerImpl<TModel extends Model = Model>
     this.modelContext = modelContext;
 
     this.modelNamespace = this.modelContext.modelNamespace;
-    this.namespace = joinLastString(this.modelNamespace, this.containerKey);
+    this.namespace = joinLastString(
+      this.modelNamespace,
+      this.containerKey,
+      this._nyaxContext.options.namespaceSeparator
+    );
 
     this.modelInstance = this._createModelInstance();
 
@@ -111,8 +115,14 @@ export class ContainerImpl<TModel extends Model = Model>
     this.effects = this.modelInstance.effects() as ExtractModelEffects<TModel>;
     this.epics = this.modelInstance.epics() as ExtractModelEpics<TModel>;
 
-    this.reducerByPath = flattenObject<ModelReducer>(this.reducers);
-    this.effectByPath = flattenObject<ModelEffect>(this.effects);
+    this.reducerByPath = flattenObject<ModelReducer>(
+      this.reducers,
+      this._nyaxContext.options.subModelSeparator
+    );
+    this.effectByPath = flattenObject<ModelEffect>(
+      this.effects,
+      this._nyaxContext.options.subModelSeparator
+    );
   }
 
   public get state(): ExtractModelState<TModel> {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,7 +31,8 @@ export function createMiddleware(nyaxContext: NyaxContext): Middleware {
     payloads.forEach((payload) => {
       const namespace = joinLastString(
         payload.modelNamespace,
-        payload.containerKey
+        payload.containerKey,
+        nyaxContext.options.namespaceSeparator
       );
 
       const container = nyaxContext.containerByNamespace.get(namespace);
@@ -99,7 +100,10 @@ export function createMiddleware(nyaxContext: NyaxContext): Middleware {
         reload(action.payload);
       }
 
-      const [namespace, actionName] = splitLastString(action.type);
+      const [namespace, actionName] = splitLastString(
+        action.type,
+        nyaxContext.options.namespaceSeparator
+      );
       let container = nyaxContext.containerByNamespace.get(namespace);
       if (!container) {
         let modelNamespace = namespace;
@@ -107,7 +111,10 @@ export function createMiddleware(nyaxContext: NyaxContext): Middleware {
 
         let model = nyaxContext.modelByModelNamespace.get(modelNamespace);
         if (!model) {
-          [modelNamespace, containerKey] = splitLastString(modelNamespace);
+          [modelNamespace, containerKey] = splitLastString(
+            modelNamespace,
+            nyaxContext.options.namespaceSeparator
+          );
           model = nyaxContext.modelByModelNamespace.get(modelNamespace);
         }
         if (model?.isLazy) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -608,7 +608,9 @@ export function registerModels(
   const registerActionPayloads: RegisterActionPayload[] = [];
 
   traverseObject(models, (item, key, parent, paths) => {
-    const modelNamespace = paths.join("/");
+    const modelNamespace = paths.join(
+      nyaxContext.options.namespaceSeparator ?? "/"
+    );
     const model = item as Exclude<typeof item, Models>;
 
     registerModel(nyaxContext, modelNamespace, model);
@@ -622,6 +624,9 @@ export function registerModels(
   return registerActionPayloads;
 }
 
-export function flattenModels(models: Models): Record<string, Model> {
-  return flattenObject(models, "/") as Record<string, Model>;
+export function flattenModels(
+  models: Models,
+  namespaceSeparator = "/"
+): Record<string, Model> {
+  return flattenObject(models, namespaceSeparator) as Record<string, Model>;
 }

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -120,7 +120,10 @@ export function createRootReducer(nyaxContext: NyaxContext): Reducer {
       return reload(rootState, action.payload);
     }
 
-    const [namespace, actionName] = splitLastString(action.type);
+    const [namespace, actionName] = splitLastString(
+      action.type,
+      nyaxContext.options.namespaceSeparator
+    );
 
     const container = nyaxContext.containerByNamespace.get(namespace);
     if (!container?.isRegistered) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,9 @@ import { GetState } from "./state";
 export interface NyaxOptions {
   dependencies: unknown;
 
+  namespaceSeparator?: string;
+  subModelSeparator?: string;
+
   createStore?: (params: {
     reducer: Reducer;
     epic: Epic;

--- a/test/test.ts
+++ b/test/test.ts
@@ -24,863 +24,891 @@ export const dependencies: Dependencies = {
 
 const ModelBase = createModelBase<Dependencies>();
 
-describe("nyax", () => {
-  it("test static model", async () => {
-    let now = 0;
+function createTests(options: {
+  namespaceSeparator?: string;
+  subModelSeparator?: string;
+}) {
+  const { namespaceSeparator, subModelSeparator } = options;
 
-    const FooModel = createModel(
-      class extends ModelBase {
-        public initialState() {
-          return {
-            foo: "foo",
-            bar: 998,
+  const separator = namespaceSeparator ?? "/";
+  return () => {
+    it("test static model", async () => {
+      let now = 0;
 
-            fooChangeCounter: 0,
-          };
-        }
-
-        public selectors() {
-          return {
-            fooBar: () => this.state.foo + this.state.bar,
-            cachedFooBar: createSelector(
-              () => this.state.foo,
-              () => this.state.bar,
-              (foo, bar) => {
-                new Array(2333333).forEach(() => {
-                  // wait
-                });
-                return foo + bar;
-              }
-            ),
-            rootState: () => this.nyax.getState(),
-          };
-        }
-
-        public reducers() {
-          return {
-            setFoo: (value: string) => {
-              this.state.foo = value;
-            },
-            setBar: (value: number) => {
-              this.state.bar = value;
-            },
-            increaseFooChangeCounter: () => {
-              this.state.fooChangeCounter += 1;
-            },
-          };
-        }
-
-        public effects() {
-          return {
-            setFooAfter10ms: async (value: string) => {
-              await timer(10).toPromise();
-              await this.actions.setFoo.dispatch(value);
-            },
-            setFooAfter20ms: async (value: string) => {
-              await timer(10).toPromise();
-              await this.actions.setFooAfter10ms.dispatch(value);
-            },
-          };
-        }
-
-        public epics() {
-          return {
-            fooChangeCounter: () =>
-              this.rootAction$.pipe(
-                filter((action) => this.actions.setFoo.is(action)),
-                map(() => this.actions.increaseFooChangeCounter.create({}))
-              ),
-          };
-        }
-      }
-    );
-
-    const { store, getContainer, getState, registerModels, reload } =
-      createNyax({
-        dependencies,
-      });
-
-    expect(() => {
-      getContainer(FooModel);
-    }).throw();
-
-    registerModels({
-      foo: FooModel,
-    });
-
-    const foo = getContainer(FooModel);
-    expect(foo.modelNamespace).eq("foo");
-    expect(foo.containerKey).eq(undefined);
-    expect(foo.canRegister).eq(false);
-    expect(foo.isRegistered).eq(true);
-
-    expect(foo.state.foo).eq("foo");
-    expect(foo.state.bar).eq(998);
-
-    foo.actions.setFoo.dispatch("fooo");
-    expect(foo.state.foo).eq("fooo");
-
-    foo.actions.setFooAfter10ms.dispatch("foo10");
-    expect(foo.state.foo).eq("fooo");
-    await timer(10).toPromise();
-    expect(foo.state.foo).eq("foo10");
-
-    expect(getState(FooModel)).eq(foo.state);
-    expect(getState(FooModel)?.foo).eq(foo.state.foo);
-
-    expect(foo.getters.rootState).eq(store.getState());
-
-    await (async () => {
-      const promise = foo.actions.setFooAfter20ms.dispatch("foo20");
-      await timer(10).toPromise();
-      expect(foo.state.foo).eq("foo10");
-      await promise;
-      expect(foo.state.foo).eq("foo20");
-    })();
-
-    expect(foo.getters.fooBar).eq("foo20998");
-    store.dispatch(foo.actions.setBar.create(233));
-    expect(foo.getters.fooBar).eq("foo20233");
-
-    now = Date.now();
-    expect(foo.getters.cachedFooBar, "foo20233");
-    expect(Date.now() - now).gt(10);
-
-    now = Date.now();
-    expect(foo.getters.cachedFooBar, "foo20233");
-    expect(Date.now() - now).lt(10);
-
-    store.dispatch({
-      type: "foo/setBar",
-      payload: 666,
-    });
-    now = Date.now();
-    expect(foo.getters.cachedFooBar, "foo20666");
-    expect(Date.now() - now).gt(10);
-
-    expect(foo.state.fooChangeCounter).eq(3);
-
-    expect(() => {
-      registerModels({
-        bar: {
-          foo: FooModel,
-        },
-      });
-    }).throw();
-
-    class BarFooModel extends FooModel {
-      public selectors() {
-        return {
-          ...super.selectors(),
-          fooGetterFooBar: () => this.getContainer(FooModel).getters.fooBar,
-          testGetContainerWithoutBind: () => {
-            const { getContainer } = this;
-            return getContainer(FooModel).getters.fooBar;
-          },
-
-          fooState: () => this.nyax.getState(FooModel),
-          testGetStateWithoutBind: () => {
-            const { getState } = this.nyax;
-            return getState(FooModel);
-          },
-        };
-      }
-    }
-    registerModels({
-      bar: {
-        foo: BarFooModel,
-      },
-    });
-
-    const barFoo = getContainer(BarFooModel);
-    expect(barFoo.modelNamespace).eq("bar/foo");
-    expect(barFoo.containerKey).eq(undefined);
-    expect(barFoo.canRegister).eq(false);
-    expect(barFoo.isRegistered).eq(true);
-
-    expect(barFoo.getters.fooBar).eq("foo998");
-
-    expect(barFoo.getters.fooGetterFooBar).eq("foo20666");
-    expect(barFoo.getters.testGetContainerWithoutBind).eq("foo20666");
-
-    expect(barFoo.getters.fooState).eq(foo.state);
-    expect(barFoo.getters.testGetStateWithoutBind).eq(foo.state);
-
-    expect(barFoo.getters.rootState).eq(store.getState());
-
-    const BarLazyFooModel = createModel(class extends FooModel {}, {
-      isLazy: true,
-    });
-    registerModels({
-      bar: {
-        lazy: {
-          foo: BarLazyFooModel,
-        },
-      },
-    });
-    const barLazyFoo = getContainer(BarLazyFooModel);
-    expect(barLazyFoo.modelNamespace).eq("bar/lazy/foo");
-    expect(barLazyFoo.containerKey).eq(undefined);
-    expect(barLazyFoo.canRegister).eq(true);
-    expect(barLazyFoo.isRegistered).eq(false);
-
-    expect(getState(BarLazyFooModel)).eq(undefined);
-
-    expect(barLazyFoo.state.foo).eq("foo");
-    expect(barLazyFoo.getters.cachedFooBar).eq("foo998");
-    expect(barLazyFoo.isRegistered).eq(false);
-
-    barLazyFoo.actions.setFoo.dispatch("for");
-    expect(barLazyFoo.state.foo).eq("for");
-    expect(barLazyFoo.getters.cachedFooBar).eq("for998");
-    expect(barLazyFoo.isRegistered).eq(true);
-
-    expect(getState(BarLazyFooModel)).eq(barLazyFoo.state);
-    expect(getState(BarLazyFooModel)?.foo).eq(barLazyFoo.state.foo);
-
-    expect(getState()).eq(store.getState());
-
-    const tempState = store.getState();
-
-    reload();
-    expect(foo.state.foo).eq("foo");
-    expect(foo.state.bar).eq(998);
-    expect(barLazyFoo.isRegistered).eq(false);
-    expect(barLazyFoo.state.foo).eq("foo");
-
-    reload(tempState);
-    expect(foo.state.foo).eq("foo20");
-    expect(foo.state.bar).eq(666);
-    expect(barLazyFoo.isRegistered).eq(true);
-    expect(barLazyFoo.state.foo).eq("for");
-  });
-
-  it("test dynamic model", async () => {
-    const BarModel = createModel(
-      class extends ModelBase {
-        public defaultArgs() {
-          return {
-            strArg: "str",
-            numArg: 233,
-            objArg: {
+      const FooModel = createModel(
+        class extends ModelBase {
+          public initialState() {
+            return {
               foo: "foo",
               bar: 998,
-            },
-            requiredStrArg: createRequiredArg("requiredStr"),
-          };
-        }
 
-        public initialState() {
-          return {
-            str: this.args.strArg,
-            num: this.args.numArg,
-            obj: this.args.objArg,
-            requiredStr: this.args.requiredStrArg,
-          };
-        }
+              fooChangeCounter: 0,
+            };
+          }
 
+          public selectors() {
+            return {
+              fooBar: () => this.state.foo + this.state.bar,
+              cachedFooBar: createSelector(
+                () => this.state.foo,
+                () => this.state.bar,
+                (foo, bar) => {
+                  new Array(2333333).forEach(() => {
+                    // wait
+                  });
+                  return foo + bar;
+                }
+              ),
+              rootState: () => this.nyax.getState(),
+            };
+          }
+
+          public reducers() {
+            return {
+              setFoo: (value: string) => {
+                this.state.foo = value;
+              },
+              setBar: (value: number) => {
+                this.state.bar = value;
+              },
+              increaseFooChangeCounter: () => {
+                this.state.fooChangeCounter += 1;
+              },
+            };
+          }
+
+          public effects() {
+            return {
+              setFooAfter10ms: async (value: string) => {
+                await timer(10).toPromise();
+                await this.actions.setFoo.dispatch(value);
+              },
+              setFooAfter20ms: async (value: string) => {
+                await timer(10).toPromise();
+                await this.actions.setFooAfter10ms.dispatch(value);
+              },
+            };
+          }
+
+          public epics() {
+            return {
+              fooChangeCounter: () =>
+                this.rootAction$.pipe(
+                  filter((action) => this.actions.setFoo.is(action)),
+                  map(() => this.actions.increaseFooChangeCounter.create({}))
+                ),
+            };
+          }
+        }
+      );
+
+      const { store, getContainer, getState, registerModels, reload } =
+        createNyax({
+          dependencies,
+          namespaceSeparator,
+        });
+
+      expect(() => {
+        getContainer(FooModel);
+      }).throw();
+
+      registerModels({
+        foo: FooModel,
+      });
+
+      const foo = getContainer(FooModel);
+      expect(foo.modelNamespace).eq("foo");
+      expect(foo.containerKey).eq(undefined);
+      expect(foo.canRegister).eq(false);
+      expect(foo.isRegistered).eq(true);
+
+      expect(foo.state.foo).eq("foo");
+      expect(foo.state.bar).eq(998);
+
+      foo.actions.setFoo.dispatch("fooo");
+      expect(foo.state.foo).eq("fooo");
+
+      foo.actions.setFooAfter10ms.dispatch("foo10");
+      expect(foo.state.foo).eq("fooo");
+      await timer(10).toPromise();
+      expect(foo.state.foo).eq("foo10");
+
+      expect(getState(FooModel)).eq(foo.state);
+      expect(getState(FooModel)?.foo).eq(foo.state.foo);
+
+      expect(foo.getters.rootState).eq(store.getState());
+
+      await (async () => {
+        const promise = foo.actions.setFooAfter20ms.dispatch("foo20");
+        await timer(10).toPromise();
+        expect(foo.state.foo).eq("foo10");
+        await promise;
+        expect(foo.state.foo).eq("foo20");
+      })();
+
+      expect(foo.getters.fooBar).eq("foo20998");
+      store.dispatch(foo.actions.setBar.create(233));
+      expect(foo.getters.fooBar).eq("foo20233");
+
+      now = Date.now();
+      expect(foo.getters.cachedFooBar, "foo20233");
+      expect(Date.now() - now).gt(10);
+
+      now = Date.now();
+      expect(foo.getters.cachedFooBar, "foo20233");
+      expect(Date.now() - now).lt(10);
+
+      store.dispatch({
+        type: `foo${separator}setBar`,
+        payload: 666,
+      });
+      now = Date.now();
+      expect(foo.getters.cachedFooBar, "foo20666");
+      expect(Date.now() - now).gt(10);
+
+      expect(foo.state.fooChangeCounter).eq(3);
+
+      expect(() => {
+        registerModels({
+          bar: {
+            foo: FooModel,
+          },
+        });
+      }).throw();
+
+      class BarFooModel extends FooModel {
         public selectors() {
           return {
-            strNum: () => this.state.str + this.state.num,
-            cachedStrNum: createSelector(
-              () => this.state.str,
-              () => this.state.num,
-              (str, num) => str + num
-            ),
-          };
-        }
+            ...super.selectors(),
+            fooGetterFooBar: () => this.getContainer(FooModel).getters.fooBar,
+            testGetContainerWithoutBind: () => {
+              const { getContainer } = this;
+              return getContainer(FooModel).getters.fooBar;
+            },
 
-        public reducers() {
-          return {
-            setStr: (value: string) => {
-              this.state.str = value;
-            },
-            setNum: (value: number) => {
-              this.state.num = value;
+            fooState: () => this.nyax.getState(FooModel),
+            testGetStateWithoutBind: () => {
+              const { getState } = this.nyax;
+              return getState(FooModel);
             },
           };
         }
-
-        public effects() {
-          return {
-            setStrAfter10ms: async (value: string) => {
-              await timer(10).toPromise();
-              await this.actions.setStr.dispatch(value);
-            },
-          };
-        }
-      },
-      {
-        isDynamic: true,
       }
-    );
-
-    const { getContainer, getState, registerModels } = createNyax({
-      dependencies,
-    });
-    registerModels({
-      bar: BarModel,
-    });
-
-    const barNyan = getContainer(BarModel, "nyan");
-    expect(barNyan.modelNamespace).eq("bar");
-    expect(barNyan.containerKey).eq("nyan");
-    expect(barNyan.canRegister).eq(true);
-    expect(barNyan.isRegistered).eq(false);
-
-    expect(getState(BarModel)).eq(undefined);
-
-    expect(barNyan.state.str).eq("str");
-    expect(barNyan.state.obj.bar).eq(998);
-    expect(barNyan.state.requiredStr).eq("requiredStr");
-    expect(barNyan.getters.strNum).eq("str233");
-    expect(barNyan.isRegistered).eq(false);
-
-    await (async () => {
-      let resolved = false;
-      const promise = barNyan.actions.setStr.dispatch("string");
-      promise.then(() => {
-        resolved = true;
+      registerModels({
+        bar: {
+          foo: BarFooModel,
+        },
       });
-      await timer(10).toPromise();
-      expect(resolved).eq(false);
-    })();
 
-    expect(() => {
-      barNyan.register();
-    }).throw();
-    barNyan.unregister();
+      const barFoo = getContainer(BarFooModel);
+      expect(barFoo.modelNamespace).eq(`bar${separator}foo`);
+      expect(barFoo.containerKey).eq(undefined);
+      expect(barFoo.canRegister).eq(false);
+      expect(barFoo.isRegistered).eq(true);
 
-    barNyan.register({
-      numArg: 123,
-      requiredStrArg: "abc",
-      objArg: {
+      expect(barFoo.getters.fooBar).eq("foo998");
+
+      expect(barFoo.getters.fooGetterFooBar).eq("foo20666");
+      expect(barFoo.getters.testGetContainerWithoutBind).eq("foo20666");
+
+      expect(barFoo.getters.fooState).eq(foo.state);
+      expect(barFoo.getters.testGetStateWithoutBind).eq(foo.state);
+
+      expect(barFoo.getters.rootState).eq(store.getState());
+
+      const BarLazyFooModel = createModel(class extends FooModel {}, {
+        isLazy: true,
+      });
+      registerModels({
+        bar: {
+          lazy: {
+            foo: BarLazyFooModel,
+          },
+        },
+      });
+      const barLazyFoo = getContainer(BarLazyFooModel);
+      expect(barLazyFoo.modelNamespace).eq(
+        `bar${separator}lazy${separator}foo`
+      );
+      expect(barLazyFoo.containerKey).eq(undefined);
+      expect(barLazyFoo.canRegister).eq(true);
+      expect(barLazyFoo.isRegistered).eq(false);
+
+      expect(getState(BarLazyFooModel)).eq(undefined);
+
+      expect(barLazyFoo.state.foo).eq("foo");
+      expect(barLazyFoo.getters.cachedFooBar).eq("foo998");
+      expect(barLazyFoo.isRegistered).eq(false);
+
+      barLazyFoo.actions.setFoo.dispatch("for");
+      expect(barLazyFoo.state.foo).eq("for");
+      expect(barLazyFoo.getters.cachedFooBar).eq("for998");
+      expect(barLazyFoo.isRegistered).eq(true);
+
+      expect(getState(BarLazyFooModel)).eq(barLazyFoo.state);
+      expect(getState(BarLazyFooModel)?.foo).eq(barLazyFoo.state.foo);
+
+      expect(getState()).eq(store.getState());
+
+      const tempState = store.getState();
+
+      reload();
+      expect(foo.state.foo).eq("foo");
+      expect(foo.state.bar).eq(998);
+      expect(barLazyFoo.isRegistered).eq(false);
+      expect(barLazyFoo.state.foo).eq("foo");
+
+      reload(tempState);
+      expect(foo.state.foo).eq("foo20");
+      expect(foo.state.bar).eq(666);
+      expect(barLazyFoo.isRegistered).eq(true);
+      expect(barLazyFoo.state.foo).eq("for");
+    });
+
+    it("test dynamic model", async () => {
+      const BarModel = createModel(
+        class extends ModelBase {
+          public defaultArgs() {
+            return {
+              strArg: "str",
+              numArg: 233,
+              objArg: {
+                foo: "foo",
+                bar: 998,
+              },
+              requiredStrArg: createRequiredArg("requiredStr"),
+            };
+          }
+
+          public initialState() {
+            return {
+              str: this.args.strArg,
+              num: this.args.numArg,
+              obj: this.args.objArg,
+              requiredStr: this.args.requiredStrArg,
+            };
+          }
+
+          public selectors() {
+            return {
+              strNum: () => this.state.str + this.state.num,
+              cachedStrNum: createSelector(
+                () => this.state.str,
+                () => this.state.num,
+                (str, num) => str + num
+              ),
+            };
+          }
+
+          public reducers() {
+            return {
+              setStr: (value: string) => {
+                this.state.str = value;
+              },
+              setNum: (value: number) => {
+                this.state.num = value;
+              },
+            };
+          }
+
+          public effects() {
+            return {
+              setStrAfter10ms: async (value: string) => {
+                await timer(10).toPromise();
+                await this.actions.setStr.dispatch(value);
+              },
+            };
+          }
+        },
+        {
+          isDynamic: true,
+        }
+      );
+
+      const { getContainer, getState, registerModels } = createNyax({
+        dependencies,
+        namespaceSeparator,
+        subModelSeparator,
+      });
+      registerModels({
+        bar: BarModel,
+      });
+
+      const barNyan = getContainer(BarModel, "nyan");
+      expect(barNyan.modelNamespace).eq("bar");
+      expect(barNyan.containerKey).eq("nyan");
+      expect(barNyan.canRegister).eq(true);
+      expect(barNyan.isRegistered).eq(false);
+
+      expect(getState(BarModel)).eq(undefined);
+
+      expect(barNyan.state.str).eq("str");
+      expect(barNyan.state.obj.bar).eq(998);
+      expect(barNyan.state.requiredStr).eq("requiredStr");
+      expect(barNyan.getters.strNum).eq("str233");
+      expect(barNyan.isRegistered).eq(false);
+
+      await (async () => {
+        let resolved = false;
+        const promise = barNyan.actions.setStr.dispatch("string");
+        promise.then(() => {
+          resolved = true;
+        });
+        await timer(10).toPromise();
+        expect(resolved).eq(false);
+      })();
+
+      expect(() => {
+        barNyan.register();
+      }).throw();
+      barNyan.unregister();
+
+      barNyan.register({
+        numArg: 123,
+        requiredStrArg: "abc",
+        objArg: {
+          foo: "666",
+          bar: 999,
+        },
+      });
+      expect(barNyan.state.num).eq(123);
+      expect(barNyan.state.requiredStr).eq("abc");
+      expect(barNyan.state.obj).deep.eq({
         foo: "666",
         bar: 999,
-      },
-    });
-    expect(barNyan.state.num).eq(123);
-    expect(barNyan.state.requiredStr).eq("abc");
-    expect(barNyan.state.obj).deep.eq({
-      foo: "666",
-      bar: 999,
-    });
-    expect(barNyan.canRegister).eq(false);
-    expect(barNyan.isRegistered).eq(true);
+      });
+      expect(barNyan.canRegister).eq(false);
+      expect(barNyan.isRegistered).eq(true);
 
-    expect(getState(BarModel)?.nyan).eq(barNyan.state);
-    expect(getState(BarModel)?.nyan?.str).eq(barNyan.state.str);
-    expect(getState(BarModel, "nyan")).eq(barNyan.state);
-    expect(getState(BarModel, "nyan")?.str).eq(barNyan.state.str);
+      expect(getState(BarModel)?.nyan).eq(barNyan.state);
+      expect(getState(BarModel)?.nyan?.str).eq(barNyan.state.str);
+      expect(getState(BarModel, "nyan")).eq(barNyan.state);
+      expect(getState(BarModel, "nyan")?.str).eq(barNyan.state.str);
 
-    expect(getState(BarModel)?.meow).eq(undefined);
-    expect(getState(BarModel, "meow")).eq(undefined);
+      expect(getState(BarModel)?.meow).eq(undefined);
+      expect(getState(BarModel, "meow")).eq(undefined);
 
-    expect(barNyan.getters.cachedStrNum).eq("str123");
-    barNyan.actions.setStr.dispatch("zzz");
-    expect(barNyan.getters.cachedStrNum).eq("zzz123");
+      expect(barNyan.getters.cachedStrNum).eq("str123");
+      barNyan.actions.setStr.dispatch("zzz");
+      expect(barNyan.getters.cachedStrNum).eq("zzz123");
 
-    const barMeow = getContainer(BarModel, "meow");
-    expect(barMeow.state.str).eq("str");
-    barMeow.register({
-      strArg: "zrO",
-      requiredStrArg: "Orz",
-    });
-    expect(barMeow.getters.cachedStrNum).eq("zrO233");
-    expect(barNyan.getters.cachedStrNum).eq("zzz123");
+      const barMeow = getContainer(BarModel, "meow");
+      expect(barMeow.state.str).eq("str");
+      barMeow.register({
+        strArg: "zrO",
+        requiredStrArg: "Orz",
+      });
+      expect(barMeow.getters.cachedStrNum).eq("zrO233");
+      expect(barNyan.getters.cachedStrNum).eq("zzz123");
 
-    const TimerModel = createModel(
-      class extends ModelBase {
-        initialState() {
-          return {
-            time: 0,
-          };
+      const TimerModel = createModel(
+        class extends ModelBase {
+          initialState() {
+            return {
+              time: 0,
+            };
+          }
+
+          reducers() {
+            return {
+              setTime: (value: number) => {
+                this.state.time = value;
+              },
+            };
+          }
         }
+      );
+      const LazyBarModel = createModel(
+        class extends BarModel {
+          public initialState() {
+            return {
+              ...super.initialState(),
+              lazy: true,
+            };
+          }
 
-        reducers() {
-          return {
-            setTime: (value: number) => {
-              this.state.time = value;
-            },
-          };
-        }
-      }
-    );
-    const LazyBarModel = createModel(
-      class extends BarModel {
-        public initialState() {
-          return {
-            ...super.initialState(),
-            lazy: true,
-          };
-        }
-
-        public epics() {
-          return {
-            0: () =>
-              interval(3).pipe(
-                map(() =>
-                  this.getContainer(TimerModel).actions.setTime.create(
-                    Date.now()
+          public epics() {
+            return {
+              0: () =>
+                interval(3).pipe(
+                  map(() =>
+                    this.getContainer(TimerModel).actions.setTime.create(
+                      Date.now()
+                    )
                   )
-                )
-              ),
-          };
+                ),
+            };
+          }
+        },
+        {
+          isDynamic: true,
+          isLazy: true,
         }
-      },
-      {
-        isDynamic: true,
-        isLazy: true,
-      }
-    );
-    registerModels({
-      lazy: {
-        bar: LazyBarModel,
-      },
-      timer: TimerModel,
+      );
+      registerModels({
+        lazy: {
+          bar: LazyBarModel,
+        },
+        timer: TimerModel,
+      });
+
+      let time = 0;
+      const lazyBarZzz = getContainer(LazyBarModel, "zzz");
+      expect(lazyBarZzz.state.str).eq("str");
+      expect(lazyBarZzz.state.lazy).eq(true);
+      const timerContainer = getContainer(TimerModel);
+      await timer(10).toPromise();
+      expect(timerContainer.state.time).eq(0);
+      lazyBarZzz.register({
+        requiredStrArg: "zzz",
+      });
+
+      expect(getState(LazyBarModel)?.zzz).eq(lazyBarZzz.state);
+
+      await timer(10).toPromise();
+      time = timerContainer.state.time;
+      expect(time).not.eq(0);
+      await timer(10).toPromise();
+      expect(timerContainer.state.time).not.eq(time);
+      time = timerContainer.state.time;
+      lazyBarZzz.unregister();
+      await timer(10).toPromise();
+      expect(timerContainer.state.time).eq(time);
+
+      expect(getState(LazyBarModel)?.zzz).eq(undefined);
+
+      const RequiredArgWithoutDefaultValueModel = createModel(
+        class extends ModelBase {
+          public defaultArgs() {
+            return {
+              foo: createRequiredArg<string>(),
+            };
+          }
+
+          public initialState() {
+            return {
+              foo: this.args.foo,
+            };
+          }
+        },
+        {
+          isDynamic: true,
+        }
+      );
+      registerModels({
+        requiredArgWithoutDefaultValue: RequiredArgWithoutDefaultValueModel,
+      });
+      const requiredArgWithoutDefaultValueFoo = getContainer(
+        RequiredArgWithoutDefaultValueModel,
+        "foo"
+      );
+      expect(() => {
+        requiredArgWithoutDefaultValueFoo.state.foo;
+      }).throw();
+      requiredArgWithoutDefaultValueFoo.unregister();
+      requiredArgWithoutDefaultValueFoo.register({
+        foo: "foo",
+      });
+      expect(requiredArgWithoutDefaultValueFoo.state.foo).eq("foo");
     });
 
-    let time = 0;
-    const lazyBarZzz = getContainer(LazyBarModel, "zzz");
-    expect(lazyBarZzz.state.str).eq("str");
-    expect(lazyBarZzz.state.lazy).eq(true);
-    const timerContainer = getContainer(TimerModel);
-    await timer(10).toPromise();
-    expect(timerContainer.state.time).eq(0);
-    lazyBarZzz.register({
-      requiredStrArg: "zzz",
+    it("test merged model", async () => {
+      const AModel = createModel(
+        class extends ModelBase {
+          public defaultArgs() {
+            return {
+              aArg: "a",
+              foo: "foo",
+            };
+          }
+
+          public initialState() {
+            return {
+              a: this.args.aArg,
+              foo: this.args.foo,
+              aStr: "aStr",
+              aNum: 1,
+              aStrChangeCounter: 0,
+            };
+          }
+
+          public selectors() {
+            return {
+              aStrNum: () => this.state.aStr + this.state.aNum,
+            };
+          }
+
+          public reducers() {
+            return {
+              setAStr: (value: string) => {
+                this.state.aStr = value;
+              },
+              increaseAStrChangeCounter: () => {
+                this.state.aStrChangeCounter += 1;
+              },
+            };
+          }
+
+          public effects() {
+            return {
+              setAStrAfter10ms: async (value: string) => {
+                await timer(10).toPromise();
+                await this.actions.setAStr.dispatch(value);
+              },
+            };
+          }
+
+          public epics() {
+            return {
+              a: () =>
+                this.rootAction$.pipe(
+                  filter((action) => this.actions.setAStr.is(action)),
+                  map(() => this.actions.increaseAStrChangeCounter.create({}))
+                ),
+            };
+          }
+        }
+      );
+
+      const BModel = createModel(
+        class extends ModelBase {
+          public defaultArgs() {
+            return {
+              bArg: "b",
+              bar: "bar",
+            };
+          }
+
+          public initialState() {
+            return {
+              b: this.args.bArg,
+              bar: this.args.bar,
+              bStr: "bStr",
+              bNum: 2,
+              bStrChangeCounter: 0,
+            };
+          }
+
+          public selectors() {
+            return {
+              bStrNum: () => this.state.bStr + this.state.bNum,
+            };
+          }
+
+          public reducers() {
+            return {
+              setBStr: (value: string) => {
+                this.state.bStr = value;
+              },
+              increaseBStrChangeCounter: () => {
+                this.state.bStrChangeCounter += 1;
+              },
+            };
+          }
+
+          public effects() {
+            return {
+              setBStrAfter10ms: async (value: string) => {
+                await timer(10).toPromise();
+                await this.actions.setBStr.dispatch(value);
+              },
+            };
+          }
+
+          public epics() {
+            return {
+              b: () =>
+                this.rootAction$.pipe(
+                  filter((action) => this.actions.setBStr.is(action)),
+                  map(() => this.actions.increaseBStrChangeCounter.create({}))
+                ),
+            };
+          }
+        }
+      );
+
+      const { getContainer, getState, registerModels } = createNyax({
+        dependencies,
+        namespaceSeparator,
+        subModelSeparator,
+      });
+
+      const ABModel = mergeModels(AModel, BModel);
+
+      registerModels({
+        ab: ABModel,
+      });
+      const ab = getContainer(ABModel);
+      expect(ab.state.a).eq("a");
+      expect(ab.state.b).eq("b");
+
+      ab.actions.setAStr.dispatch("aa");
+      expect(ab.state.aStr).eq("aa");
+      expect(ab.getters.aStrNum).eq("aa1");
+      expect(ab.state.bStr).eq("bStr");
+      expect(ab.getters.bStrNum).eq("bStr2");
+
+      expect(getState(ABModel)?.aStr).eq(ab.state.aStr);
+
+      await ab.actions.setBStrAfter10ms.dispatch("bb");
+      expect(ab.getters.bStrNum).eq("bb2");
+
+      expect(ab.state.aStrChangeCounter).eq(1);
+      expect(ab.state.bStrChangeCounter).eq(1);
+
+      const ABSubABModel = createModel(
+        mergeModels(
+          AModel,
+          BModel,
+          mergeSubModels({
+            subA: AModel,
+            subB: BModel,
+          })
+        ),
+        {
+          isDynamic: true,
+          isLazy: true,
+        }
+      );
+      registerModels({
+        spring: {
+          nyan: ABSubABModel,
+        },
+      });
+      const abSubABMeow = getContainer(ABSubABModel, "meow");
+      expect(abSubABMeow.modelNamespace).eq(`spring${separator}nyan`);
+      expect(abSubABMeow.containerKey).eq("meow");
+      expect(abSubABMeow.canRegister).eq(true);
+      expect(abSubABMeow.isRegistered).eq(false);
+
+      expect(abSubABMeow.state.aNum).eq(1);
+      expect(abSubABMeow.state.foo).eq("foo");
+      expect(abSubABMeow.state.bNum).eq(2);
+      expect(abSubABMeow.state.bar).eq("bar");
+      expect(abSubABMeow.state.subA.aStr).eq("aStr");
+      expect(abSubABMeow.state.subB.bStr).eq("bStr");
+
+      abSubABMeow.register({
+        aArg: "aa",
+        bar: "boom",
+        subA: {
+          foo: "for",
+        },
+      });
+      expect(abSubABMeow.state.foo).eq("foo");
+      expect(abSubABMeow.state.bar).eq("boom");
+      expect(abSubABMeow.state.subA.foo).eq("for");
+      expect(abSubABMeow.state.subA.a).eq("a");
+      expect(abSubABMeow.state.subB.bar).eq("bar");
+      expect(abSubABMeow.state.subB.b).eq("b");
+
+      expect(getState(ABSubABModel)?.meow?.subA).eq(abSubABMeow.state.subA);
+
+      const subA = createSubContainer(abSubABMeow, "subA");
+      const subB = createSubContainer(abSubABMeow, "subB");
+
+      expect(subA.state.foo).eq("for");
+      expect(subA.getters.aStrNum).eq("aStr1");
+
+      await subB.actions.setBStrAfter10ms.dispatch("bbb");
+      expect(subB.getters.bStrNum).eq("bbb2");
+      expect(abSubABMeow.state.subB.bStrChangeCounter).eq(1);
+
+      expect(subA.actions.setAStr.create("aaa")).deep.eq({
+        type: [
+          "spring",
+          "nyan",
+          "meow",
+          `subA${subModelSeparator ?? "."}setAStr`,
+        ].join(separator),
+        payload: "aaa",
+      });
     });
 
-    expect(getState(LazyBarModel)?.zzz).eq(lazyBarZzz.state);
+    it("test unhandled error", async () => {
+      let okCounter = 0;
+      let effectErrorCounter = 0;
+      let effectCatchedCounter = 0;
+      let epicErrorCounter = 0;
 
-    await timer(10).toPromise();
-    time = timerContainer.state.time;
-    expect(time).not.eq(0);
-    await timer(10).toPromise();
-    expect(timerContainer.state.time).not.eq(time);
-    time = timerContainer.state.time;
-    lazyBarZzz.unregister();
-    await timer(10).toPromise();
-    expect(timerContainer.state.time).eq(time);
+      const ErrorModel = createModel(
+        class extends ModelBase {
+          public reducers() {
+            return {
+              ok: () => {
+                return;
+              },
+              epic: () => {
+                return;
+              },
+            };
+          }
 
-    expect(getState(LazyBarModel)?.zzz).eq(undefined);
-
-    const RequiredArgWithoutDefaultValueModel = createModel(
-      class extends ModelBase {
-        public defaultArgs() {
-          return {
-            foo: createRequiredArg<string>(),
-          };
-        }
-
-        public initialState() {
-          return {
-            foo: this.args.foo,
-          };
-        }
-      },
-      {
-        isDynamic: true,
-      }
-    );
-    registerModels({
-      requiredArgWithoutDefaultValue: RequiredArgWithoutDefaultValueModel,
-    });
-    const requiredArgWithoutDefaultValueFoo = getContainer(
-      RequiredArgWithoutDefaultValueModel,
-      "foo"
-    );
-    expect(() => {
-      requiredArgWithoutDefaultValueFoo.state.foo;
-    }).throw();
-    requiredArgWithoutDefaultValueFoo.unregister();
-    requiredArgWithoutDefaultValueFoo.register({
-      foo: "foo",
-    });
-    expect(requiredArgWithoutDefaultValueFoo.state.foo).eq("foo");
-  });
-
-  it("test merged model", async () => {
-    const AModel = createModel(
-      class extends ModelBase {
-        public defaultArgs() {
-          return {
-            aArg: "a",
-            foo: "foo",
-          };
-        }
-
-        public initialState() {
-          return {
-            a: this.args.aArg,
-            foo: this.args.foo,
-            aStr: "aStr",
-            aNum: 1,
-            aStrChangeCounter: 0,
-          };
-        }
-
-        public selectors() {
-          return {
-            aStrNum: () => this.state.aStr + this.state.aNum,
-          };
-        }
-
-        public reducers() {
-          return {
-            setAStr: (value: string) => {
-              this.state.aStr = value;
-            },
-            increaseAStrChangeCounter: () => {
-              this.state.aStrChangeCounter += 1;
-            },
-          };
-        }
-
-        public effects() {
-          return {
-            setAStrAfter10ms: async (value: string) => {
-              await timer(10).toPromise();
-              await this.actions.setAStr.dispatch(value);
-            },
-          };
-        }
-
-        public epics() {
-          return {
-            a: () =>
-              this.rootAction$.pipe(
-                filter((action) => this.actions.setAStr.is(action)),
-                map(() => this.actions.increaseAStrChangeCounter.create({}))
-              ),
-          };
-        }
-      }
-    );
-
-    const BModel = createModel(
-      class extends ModelBase {
-        public defaultArgs() {
-          return {
-            bArg: "b",
-            bar: "bar",
-          };
-        }
-
-        public initialState() {
-          return {
-            b: this.args.bArg,
-            bar: this.args.bar,
-            bStr: "bStr",
-            bNum: 2,
-            bStrChangeCounter: 0,
-          };
-        }
-
-        public selectors() {
-          return {
-            bStrNum: () => this.state.bStr + this.state.bNum,
-          };
-        }
-
-        public reducers() {
-          return {
-            setBStr: (value: string) => {
-              this.state.bStr = value;
-            },
-            increaseBStrChangeCounter: () => {
-              this.state.bStrChangeCounter += 1;
-            },
-          };
-        }
-
-        public effects() {
-          return {
-            setBStrAfter10ms: async (value: string) => {
-              await timer(10).toPromise();
-              await this.actions.setBStr.dispatch(value);
-            },
-          };
-        }
-
-        public epics() {
-          return {
-            b: () =>
-              this.rootAction$.pipe(
-                filter((action) => this.actions.setBStr.is(action)),
-                map(() => this.actions.increaseBStrChangeCounter.create({}))
-              ),
-          };
-        }
-      }
-    );
-
-    const { getContainer, getState, registerModels } = createNyax({
-      dependencies,
-    });
-
-    const ABModel = mergeModels(AModel, BModel);
-
-    registerModels({
-      ab: ABModel,
-    });
-    const ab = getContainer(ABModel);
-    expect(ab.state.a).eq("a");
-    expect(ab.state.b).eq("b");
-
-    ab.actions.setAStr.dispatch("aa");
-    expect(ab.state.aStr).eq("aa");
-    expect(ab.getters.aStrNum).eq("aa1");
-    expect(ab.state.bStr).eq("bStr");
-    expect(ab.getters.bStrNum).eq("bStr2");
-
-    expect(getState(ABModel)?.aStr).eq(ab.state.aStr);
-
-    await ab.actions.setBStrAfter10ms.dispatch("bb");
-    expect(ab.getters.bStrNum).eq("bb2");
-
-    expect(ab.state.aStrChangeCounter).eq(1);
-    expect(ab.state.bStrChangeCounter).eq(1);
-
-    const ABSubABModel = createModel(
-      mergeModels(
-        AModel,
-        BModel,
-        mergeSubModels({
-          subA: AModel,
-          subB: BModel,
-        })
-      ),
-      {
-        isDynamic: true,
-        isLazy: true,
-      }
-    );
-    registerModels({
-      spring: {
-        nyan: ABSubABModel,
-      },
-    });
-    const abSubABMeow = getContainer(ABSubABModel, "meow");
-    expect(abSubABMeow.modelNamespace).eq("spring/nyan");
-    expect(abSubABMeow.containerKey).eq("meow");
-    expect(abSubABMeow.canRegister).eq(true);
-    expect(abSubABMeow.isRegistered).eq(false);
-
-    expect(abSubABMeow.state.aNum).eq(1);
-    expect(abSubABMeow.state.foo).eq("foo");
-    expect(abSubABMeow.state.bNum).eq(2);
-    expect(abSubABMeow.state.bar).eq("bar");
-    expect(abSubABMeow.state.subA.aStr).eq("aStr");
-    expect(abSubABMeow.state.subB.bStr).eq("bStr");
-
-    abSubABMeow.register({
-      aArg: "aa",
-      bar: "boom",
-      subA: {
-        foo: "for",
-      },
-    });
-    expect(abSubABMeow.state.foo).eq("foo");
-    expect(abSubABMeow.state.bar).eq("boom");
-    expect(abSubABMeow.state.subA.foo).eq("for");
-    expect(abSubABMeow.state.subA.a).eq("a");
-    expect(abSubABMeow.state.subB.bar).eq("bar");
-    expect(abSubABMeow.state.subB.b).eq("b");
-
-    expect(getState(ABSubABModel)?.meow?.subA).eq(abSubABMeow.state.subA);
-
-    const subA = createSubContainer(abSubABMeow, "subA");
-    const subB = createSubContainer(abSubABMeow, "subB");
-
-    expect(subA.state.foo).eq("for");
-    expect(subA.getters.aStrNum).eq("aStr1");
-
-    await subB.actions.setBStrAfter10ms.dispatch("bbb");
-    expect(subB.getters.bStrNum).eq("bbb2");
-    expect(abSubABMeow.state.subB.bStrChangeCounter).eq(1);
-
-    expect(subA.actions.setAStr.create("aaa")).deep.eq({
-      type: "spring/nyan/meow/subA.setAStr",
-      payload: "aaa",
-    });
-  });
-
-  it("test unhandled error", async () => {
-    let okCounter = 0;
-    let effectErrorCounter = 0;
-    let effectCatchedCounter = 0;
-    let epicErrorCounter = 0;
-
-    const ErrorModel = createModel(
-      class extends ModelBase {
-        public reducers() {
-          return {
-            ok: () => {
-              return;
-            },
-            epic: () => {
-              return;
-            },
-          };
-        }
-
-        public effects() {
-          return {
-            effect: async () => {
-              await timer(5).toPromise();
-              throw new Error("effect error");
-            },
-            effect2: async () => {
-              await timer(5).toPromise();
-              await this.actions.effect.dispatch({});
-            },
-            effect3: async () => {
-              await timer(5).toPromise();
-              await this.actions.effect2.dispatch({});
-            },
-            effectCatchInner: async () => {
-              await timer(5).toPromise();
-              try {
+          public effects() {
+            return {
+              effect: async () => {
+                await timer(5).toPromise();
+                throw new Error("effect error");
+              },
+              effect2: async () => {
+                await timer(5).toPromise();
                 await this.actions.effect.dispatch({});
-              } catch {
-                // noop
-              }
-            },
-          };
-        }
+              },
+              effect3: async () => {
+                await timer(5).toPromise();
+                await this.actions.effect2.dispatch({});
+              },
+              effectCatchInner: async () => {
+                await timer(5).toPromise();
+                try {
+                  await this.actions.effect.dispatch({});
+                } catch {
+                  // noop
+                }
+              },
+            };
+          }
 
-        public epics() {
-          return {
-            0: () =>
-              this.rootAction$.pipe(
-                filter((action) => this.actions.epic.is(action)),
-                map(() => {
-                  throw new Error("epic error");
-                })
-              ),
-            1: () =>
-              this.rootAction$.pipe(
-                filter((action) => this.actions.ok.is(action)),
-                mergeMap(() => {
-                  okCounter += 1;
-                  return empty();
-                })
-              ),
-          };
+          public epics() {
+            return {
+              0: () =>
+                this.rootAction$.pipe(
+                  filter((action) => this.actions.epic.is(action)),
+                  map(() => {
+                    throw new Error("epic error");
+                  })
+                ),
+              1: () =>
+                this.rootAction$.pipe(
+                  filter((action) => this.actions.ok.is(action)),
+                  mergeMap(() => {
+                    okCounter += 1;
+                    return empty();
+                  })
+                ),
+            };
+          }
         }
-      }
-    );
+      );
 
-    const { getContainer, registerModels } = createNyax({
-      dependencies,
-      onUnhandledEffectError: (error, promise, context) => {
-        promise?.catch(() => {
+      const { getContainer, registerModels } = createNyax({
+        dependencies,
+        onUnhandledEffectError: (error, promise, context) => {
+          promise?.catch(() => {
+            // noop
+          });
+          expect((error as Error).message).eq("effect error");
+          expect(context?.container?.modelNamespace).eq("err");
+          expect(!!context?.action?.type).eq(true);
+          effectErrorCounter += 1;
+        },
+        onUnhandledEpicError: (error, caught, context) => {
+          expect((error as Error).message).eq("epic error");
+          expect(context?.container?.modelNamespace).eq("err");
+          epicErrorCounter += 1;
+          return caught;
+        },
+        namespaceSeparator,
+        subModelSeparator,
+      });
+
+      registerModels({
+        err: ErrorModel,
+      });
+
+      const err = getContainer(ErrorModel);
+      err.actions.ok.dispatch({});
+      expect(okCounter).eq(1);
+      err.actions.epic.dispatch({});
+      expect(epicErrorCounter).eq(1);
+      err.actions.ok.dispatch({});
+      expect(okCounter).eq(2);
+      err.actions.epic.dispatch({});
+      expect(epicErrorCounter).eq(2);
+
+      err.actions.effect.dispatch({}).then(
+        () => {
+          // noop
+        },
+        () => {
+          // noop
+        }
+      );
+      expect(effectErrorCounter).eq(0);
+
+      err.actions.effect.dispatch({}).catch(() => {
+        // noop
+      });
+      expect(effectErrorCounter).eq(0);
+
+      err.actions.effect
+        .dispatch({})
+        .then(() => {
+          // noop
+        })
+        .catch(() => {
           // noop
         });
-        expect((error as Error).message).eq("effect error");
-        expect(context?.container?.modelNamespace).eq("err");
-        expect(!!context?.action?.type).eq(true);
-        effectErrorCounter += 1;
-      },
-      onUnhandledEpicError: (error, caught, context) => {
-        expect((error as Error).message).eq("epic error");
-        expect(context?.container?.modelNamespace).eq("err");
-        epicErrorCounter += 1;
-        return caught;
-      },
-    });
+      await timer(50).toPromise();
+      expect(effectErrorCounter).eq(1);
+      expect(effectCatchedCounter).eq(0);
 
-    registerModels({
-      err: ErrorModel,
-    });
-
-    const err = getContainer(ErrorModel);
-    err.actions.ok.dispatch({});
-    expect(okCounter).eq(1);
-    err.actions.epic.dispatch({});
-    expect(epicErrorCounter).eq(1);
-    err.actions.ok.dispatch({});
-    expect(okCounter).eq(2);
-    err.actions.epic.dispatch({});
-    expect(epicErrorCounter).eq(2);
-
-    err.actions.effect.dispatch({}).then(
-      () => {
-        // noop
-      },
-      () => {
-        // noop
+      try {
+        await err.actions.effect.dispatch({});
+      } catch {
+        effectCatchedCounter += 1;
       }
-    );
-    expect(effectErrorCounter).eq(0);
+      await timer(50).toPromise();
+      expect(effectErrorCounter).eq(1);
+      expect(effectCatchedCounter).eq(1);
 
-    err.actions.effect.dispatch({}).catch(() => {
-      // noop
+      err.actions.effect2.dispatch({});
+      await timer(50).toPromise();
+      expect(effectErrorCounter).eq(2);
+      expect(effectCatchedCounter).eq(1);
+
+      try {
+        await err.actions.effect2.dispatch({});
+      } catch {
+        effectCatchedCounter += 1;
+      }
+      await timer(50).toPromise();
+      expect(effectErrorCounter).eq(2);
+      expect(effectCatchedCounter).eq(2);
+
+      err.actions.effect3
+        .dispatch({})
+        .then(() => {
+          // noop
+        })
+        .catch(() => {
+          // noop
+        });
+      await timer(50).toPromise();
+      expect(effectErrorCounter).eq(3);
+      expect(effectCatchedCounter).eq(2);
+
+      try {
+        await err.actions.effect3.dispatch({});
+      } catch {
+        effectCatchedCounter += 1;
+      }
+      await timer(50).toPromise();
+      expect(effectErrorCounter).eq(3);
+      expect(effectCatchedCounter).eq(3);
+
+      err.actions.effectCatchInner.dispatch({});
+      await timer(50).toPromise();
+      expect(effectErrorCounter).eq(3);
     });
-    expect(effectErrorCounter).eq(0);
+  };
+}
 
-    err.actions.effect
-      .dispatch({})
-      .then(() => {
-        // noop
-      })
-      .catch(() => {
-        // noop
-      });
-    await timer(50).toPromise();
-    expect(effectErrorCounter).eq(1);
-    expect(effectCatchedCounter).eq(0);
-
-    try {
-      await err.actions.effect.dispatch({});
-    } catch {
-      effectCatchedCounter += 1;
-    }
-    await timer(50).toPromise();
-    expect(effectErrorCounter).eq(1);
-    expect(effectCatchedCounter).eq(1);
-
-    err.actions.effect2.dispatch({});
-    await timer(50).toPromise();
-    expect(effectErrorCounter).eq(2);
-    expect(effectCatchedCounter).eq(1);
-
-    try {
-      await err.actions.effect2.dispatch({});
-    } catch {
-      effectCatchedCounter += 1;
-    }
-    await timer(50).toPromise();
-    expect(effectErrorCounter).eq(2);
-    expect(effectCatchedCounter).eq(2);
-
-    err.actions.effect3
-      .dispatch({})
-      .then(() => {
-        // noop
-      })
-      .catch(() => {
-        // noop
-      });
-    await timer(50).toPromise();
-    expect(effectErrorCounter).eq(3);
-    expect(effectCatchedCounter).eq(2);
-
-    try {
-      await err.actions.effect3.dispatch({});
-    } catch {
-      effectCatchedCounter += 1;
-    }
-    await timer(50).toPromise();
-    expect(effectErrorCounter).eq(3);
-    expect(effectCatchedCounter).eq(3);
-
-    err.actions.effectCatchInner.dispatch({});
-    await timer(50).toPromise();
-    expect(effectErrorCounter).eq(3);
-  });
-});
+describe("nyax", createTests({}));
+describe(
+  "nyax - customized separator",
+  createTests({ namespaceSeparator: "+", subModelSeparator: "^" })
+);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function testTypes() {


### PR DESCRIPTION
Sometimes dynamic container can have reserved char as containerKey, like "/" or ".". In this case, the reducer action parse will fail. This change would like to introduce a custom action separator to bypass.

@SpringNyan , any suggestion ?